### PR TITLE
Stream redesign

### DIFF
--- a/backend/fastrtc/webrtc_connection_mixin.py
+++ b/backend/fastrtc/webrtc_connection_mixin.py
@@ -123,7 +123,13 @@ class WebRTCConnectionMixin:
         logger.debug("Starting to handle offer")
         logger.debug("Offer body %s", body)
         if len(self.connections) >= cast(int, self.concurrency_limit):
-            return {"status": "failed"}
+            return {
+                "status": "failed",
+                "meta": {
+                    "error": "concurrency_limit_reached",
+                    "limit": self.concurrency_limit,
+                },
+            }
 
         offer = RTCSessionDescription(sdp=body["sdp"], type=body["type"])
 

--- a/backend/fastrtc/websocket.py
+++ b/backend/fastrtc/websocket.py
@@ -2,7 +2,7 @@ import asyncio
 import audioop
 import base64
 import logging
-from typing import Any, Callable, Optional, cast
+from typing import Any, Awaitable, Callable, Optional, cast
 
 import anyio
 import librosa
@@ -48,7 +48,7 @@ class WebSocketHandler:
     def __init__(
         self,
         stream_handler: StreamHandlerImpl,
-        set_handler: Callable[[str, "WebSocketHandler"], None],
+        set_handler: Callable[[str, "WebSocketHandler"], Awaitable[None]],
         clean_up: Callable[[str], None],
         additional_outputs_factory: Callable[
             [str], Callable[[AdditionalOutputs], None]
@@ -114,7 +114,7 @@ class WebSocketHandler:
                     self.set_additional_outputs = self.set_additional_outputs_factory(
                         self.stream_id
                     )
-                    self.set_handler(self.stream_id, self)
+                    await self.set_handler(self.stream_id, self)
                 elif message["event"] == "stop":
                     self.quit.set()
                     self.clean_up(cast(str, self.stream_id))

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,14 +31,11 @@ pip install fastrtc[vad, tts]
 ## Quickstart
 
 Import the [Stream](userguide/streams) class and pass in a [handler](userguide/streams/#handlers).
-The `Stream` is a [FastAPI](https://fastapi.tiangolo.com/) app that comes with the following routes:
+The `Stream` has three main methods:
 
-- `/ui`: A Gradio UI for testing your stream.
-- `/webrtc/docs`: Documentation and Gradio UI for WebRTC connections.
-- `/websocket/docs`: Documentation for WebSocket connections.
-- `/telephone/docs`: Documentation for telephone integration.
-
-Launch the stream how you would any FastAPI app. Or use the `fastphone()` method to launch the stream and get a free temporary phone number!
+- `.ui.launch()`: Launch a built-in UI for easily testing and sharing your stream. Built with [Gradio](https://www.gradio.app/).
+- `.fastphone()`: Get a free temporary phone number to call into your stream. Hugging Face token required.
+- `.mount(app)`: Mount the stream on a [FastAPI](https://fastapi.tiangolo.com/) app. Perfect for integrating with your already existing production system.
 
 
 === "Echo Audio"
@@ -60,15 +57,22 @@ Launch the stream how you would any FastAPI app. Or use the `fastphone()` method
         mode="send-receive",
     )
 
-    # Optional: Add any routes
-    @stream.get("/")
+    # Launch the built-in UI
+    stream.ui.launch()
+
+    # OR use fastphone to get a free phone number! (HF token required)
+    stream.fastphone()
+
+    # Or mount the stream on a FastAPI app
+    app = FastAPI()
+    stream.mount(app)
+
+    @app.get("/")
     async def _():
         return HTMLResponse(content=open("index.html").read())
 
     # launch the stream
-    # uvicorn app:stream --host 0.0.0.0 --port 8000
-    # OR use fastphone to get a free phone number! (HF token required)
-    stream.fastphone()
+    # uvicorn app:app --host 0.0.0.0 --port 8000
     ```
 
 === "Object Detection"
@@ -89,14 +93,23 @@ Launch the stream how you would any FastAPI app. Or use the `fastphone()` method
             gr.Slider(minimum=0, maximum=1, step=0.01, value=0.3)
         ]
     )
+    
+    # Launch the built-in UI
+    stream.ui.launch()
+
+    # OR use fastphone to get a free phone number! (HF token required)
+    stream.fastphone()
+
+    # Or mount the stream on a FastAPI app
+    app = FastAPI()
+    stream.mount(app)
 
     # Optional: Add routes
-    @stream.get("/")
+    @app.get("/")
     async def _():
         return HTMLResponse(content=open("index.html").read())
 
-    # launch the stream
-    # uvicorn app:stream --host 0.0.0.0 --port 8000
+    # uvicorn app:app --host 0.0.0.0 --port 8000
     ```
 
 === "LLM Voice Chat"
@@ -162,8 +175,18 @@ Launch the stream how you would any FastAPI app. Or use the `fastphone()` method
 
     )
 
+    # Launch the built-in UI
+    stream.ui.launch()
+
+    # OR use fastphone to get a free phone number! (HF token required)
+    stream.fastphone()
+
+    # Or mount the stream on a FastAPI app
+    app = FastAPI()
+    stream.mount(app)
+
     # launch the stream
-    # uvicorn app:stream --host 0.0.0.0 --port 8000
+    # uvicorn app:app --host 0.0.0.0 --port 8000
     ```
 
     1. The python generator will receive the **entire** audio up until the user stopped. It will be a tuple of the form (sampling_rate, numpy array of audio). The array will have a shape of (1, num_samples).
@@ -185,11 +208,13 @@ Learn more about the [Stream](userguide/streams) in the user guide.
 
 :speaking_head:{ .lg } Automatic Voice Detection and Turn Taking built-in, only worry about the logic for responding to the user.
 
-:material-lightning-bolt:{ .lg } Automatic Gradio UI and API Docs - Go to `http://localhost:8080/webrtc/docs` to try your app with a Gradio UI. The page will also display docs on how to connect with your own javascript frontend over WebRTC.
+:material-laptop:{ .lg } Automatic UI - Use the `.ui.launch()` method to launch the webRTC-enabled built-in Gradio UI.
 
-:simple-webstorm:{ .lg } Automatic WebSocket API - Go to `http://localhost:8080/websocket/docs` to see the docs on how to connect to the server over websockets with your own javascript frontend.
+:material-lightning-bolt:{ .lg } Automatic WebRTC Support - Use the `.mount(app)` method to mount the stream on a FastAPI app and get a webRTC endpoint for your own frontend! 
 
-:telephone:{ .lg } Automatic Telephone Support - Us the `fastphone()` method of the stream to launch the application and get a free temporary phone number! Go to `http://localhost:8080/telephone/docs` to see the docs on how to call into the server with your own phone.
+:simple-webstorm:{ .lg } Websocket Support - Use the `.mount(app)` method to mount the stream on a FastAPI app and get a websocket endpoint for your own frontend! 
+
+:telephone:{ .lg } Automatic Telephone Support - Us the `fastphone()` method of the stream to launch the application and get a free temporary phone number!
 
 :robot:{ .lg } Completely customizable backend - A `Stream` is just a FastAPI app so you can easily extend it to fit your production application. See the [Talk To Claude](https://huggingface.co/spaces/fastrtc/talk-to-claude) demo for an example on how to serve a custom JS frontend.
 

--- a/frontend/Index.svelte
+++ b/frontend/Index.svelte
@@ -13,7 +13,7 @@
 	export let elem_classes: string[] = [];
 	export let visible = true;
 	export let value: string = "__webrtc_value__";
-	export let button_labels: {start: string, stop: string, waiting: string};
+	export let button_labels: { start: string; stop: string; waiting: string };
 
 	export let label: string;
 	export let root: string;
@@ -40,20 +40,41 @@
 	export let pulse_color: string = "var(--color-accent)";
 
 	const on_change_cb = (msg: "change" | "tick" | any) => {
-		if (msg?.type === "info" || msg?.type === "warning" || msg?.type === "error") {
+		if (
+			msg?.type === "info" ||
+			msg?.type === "warning" ||
+			msg?.type === "error"
+		) {
 			console.log("dispatching info", msg.message);
-			gradio.dispatch(msg?.type === "error"? "error": "warning", msg.message);
-		} else if (msg?.type === "fetch_output"){
+			gradio.dispatch(
+				msg?.type === "error" ? "error" : "warning",
+				msg.message,
+			);
+		} else if (msg?.type === "fetch_output") {
 			gradio.dispatch("state_change");
 		} else if (msg?.type === "send_input") {
 			gradio.dispatch("tick");
 		}
-		gradio.dispatch(msg === "change" ? "state_change" : "tick");
-	}
+		if (msg.type === "state_change") {
+			gradio.dispatch(msg === "change" ? "state_change" : "tick");
+		}
+	};
+
+	const reject_cb = (msg: object) => {
+		if (
+			msg.status === "failed" &&
+			msg.meta?.error === "concurrency_limit_reached"
+		) {
+			gradio.dispatch(
+				"error",
+				`Too many concurrent connections. Please try again later!`,
+			);
+		} else {
+			gradio.dispatch("error", "Unexpected server error");
+		}
+	};
 
 	let dragging = false;
-
-	$: console.log("value", value);
 </script>
 
 <Block
@@ -69,17 +90,17 @@
 	{scale}
 	{min_width}
 	allow_overflow={false}
-	>
-		<StatusTracker
-			autoscroll={gradio.autoscroll}
-			i18n={gradio.i18n}
-			{...loading_status}
-			on:clear_status={() => gradio.dispatch("clear_status", loading_status)}
-		/>
+>
+	<StatusTracker
+		autoscroll={gradio.autoscroll}
+		i18n={gradio.i18n}
+		{...loading_status}
+		on:clear_status={() => gradio.dispatch("clear_status", loading_status)}
+	/>
 
 	{#if mode == "receive" && modality === "video"}
 		<StaticVideo
-			bind:value={value}
+			bind:value
 			{on_change_cb}
 			{label}
 			{show_label}
@@ -90,7 +111,7 @@
 		/>
 	{:else if mode == "receive" && modality === "audio"}
 		<StaticAudio
-			bind:value={value}
+			bind:value
 			{on_change_cb}
 			{label}
 			{show_label}
@@ -102,11 +123,10 @@
 			i18n={gradio.i18n}
 			on:tick={() => gradio.dispatch("tick")}
 			on:error={({ detail }) => gradio.dispatch("error", detail)}
-
 		/>
 	{:else if (mode === "send-receive" || mode == "send") && (modality === "video" || modality == "audio-video")}
 		<Video
-			bind:value={value}
+			bind:value
 			{label}
 			{show_label}
 			active_source={"webcam"}
@@ -118,6 +138,7 @@
 			{track_constraints}
 			{rtp_params}
 			{on_change_cb}
+			{reject_cb}
 			{icon}
 			{icon_button_color}
 			{pulse_color}
@@ -139,7 +160,7 @@
 		</Video>
 	{:else if (mode === "send-receive" || mode === "send") && modality === "audio"}
 		<InteractiveAudio
-			bind:value={value}
+			bind:value
 			{on_change_cb}
 			{label}
 			{show_label}
@@ -151,6 +172,7 @@
 			{rtp_params}
 			i18n={gradio.i18n}
 			{icon}
+			{reject_cb}
 			{icon_button_color}
 			{pulse_color}
 			{button_labels}

--- a/frontend/shared/InteractiveAudio.svelte
+++ b/frontend/shared/InteractiveAudio.svelte
@@ -29,6 +29,7 @@
     export let track_constraints: MediaTrackConstraints = {};
     export let rtp_params: RTCRtpParameters = {} as RTCRtpParameters;
     export let on_change_cb: (mg: "tick" | "change") => void;
+    export let reject_cb: (msg: object) => void;
     export let icon: string | undefined = undefined;
     export let icon_button_color: string = "var(--color-accent)";
     export let pulse_color: string = "var(--color-accent)";
@@ -50,7 +51,6 @@
     let _on_change_cb = (msg: "change" | "tick" | "stopword") => {
         console.log("msg", msg);
         if (msg === "stopword") {
-            console.log("stopword recognized");
             stopword_recognized = true;
             setTimeout(() => {
                 stopword_recognized = false;
@@ -198,16 +198,14 @@
             _on_change_cb,
             rtp_params,
             additional_message_cb,
+            reject_cb,
         )
             .then((connection) => {
                 pc = connection;
             })
             .catch(() => {
                 console.info("catching");
-                dispatch(
-                    "error",
-                    "Too many concurrent users. Come back later!",
-                );
+                stream_state = "closed";
             });
     }
 

--- a/frontend/shared/InteractiveVideo.svelte
+++ b/frontend/shared/InteractiveVideo.svelte
@@ -25,6 +25,7 @@
 	export let track_constraints: MediaTrackConstraints = {};
 	export let mode: "send" | "send-receive";
 	export let on_change_cb: (msg: "change" | "tick") => void;
+	export let reject_cb: (msg: object) => void;
 	export let rtp_params: RTCRtpParameters = {} as RTCRtpParameters;
 	export let icon: string | undefined | ComponentType = undefined;
 	export let icon_button_color: string = "var(--color-accent)";
@@ -72,6 +73,7 @@
 		stream_every={0.5}
 		{server}
 		bind:webrtc_id={value}
+		{reject_cb}
 	/>
 
 	<!-- <SelectSource {sources} bind:active_source /> -->

--- a/frontend/shared/Webcam.svelte
+++ b/frontend/shared/Webcam.svelte
@@ -6,7 +6,7 @@
 		Square,
 		DropdownArrow,
 		Spinner,
-        Microphone as Mic
+		Microphone as Mic,
 	} from "@gradio/icons";
 	import type { I18nFormatter } from "@gradio/utils";
 	import { StreamingBar } from "@gradio/statustracker";
@@ -15,29 +15,30 @@
 	import {
 		get_devices,
 		get_video_stream,
-		set_available_devices
+		set_available_devices,
 	} from "./stream_utils";
-    import { start, stop } from "./webrtc_utils";
-    import PulsingIcon from "./PulsingIcon.svelte";
+	import { start, stop } from "./webrtc_utils";
+	import PulsingIcon from "./PulsingIcon.svelte";
 
 	let video_source: HTMLVideoElement;
 	let available_video_devices: MediaDeviceInfo[] = [];
 	let selected_device: MediaDeviceInfo | null = null;
 	let _time_limit: number | null = null;
-    export let time_limit: number | null = null;
+	export let time_limit: number | null = null;
 	let stream_state: "open" | "waiting" | "closed" = "closed";
 	export let on_change_cb: (msg: "tick" | "change") => void;
+	export let reject_cb: (msg: object) => void;
 	export let mode: "send-receive" | "send";
-    const _webrtc_id = Math.random().toString(36).substring(2);
+	const _webrtc_id = Math.random().toString(36).substring(2);
 	export let rtp_params: RTCRtpParameters = {} as RTCRtpParameters;
 	export let icon: string | undefined | ComponentType = undefined;
-    export let icon_button_color: string = "var(--color-accent)";
-    export let pulse_color: string = "var(--color-accent)";
-	export let button_labels: {start: string, stop: string, waiting: string};
+	export let icon_button_color: string = "var(--color-accent)";
+	export let pulse_color: string = "var(--color-accent)";
+	export let button_labels: { start: string; stop: string; waiting: string };
 
-	export const modify_stream: (state: "open" | "closed" | "waiting") => void = (
-		state: "open" | "closed" | "waiting"
-	) => {
+	export const modify_stream: (
+		state: "open" | "closed" | "waiting",
+	) => void = (state: "open" | "closed" | "waiting") => {
 		if (state === "closed") {
 			_time_limit = null;
 			stream_state = "closed";
@@ -50,7 +51,7 @@
 
 	let canvas: HTMLCanvasElement;
 	export let track_constraints: MediaTrackConstraints | null = null;
-    export let rtc_configuration: Object;
+	export let rtc_configuration: Object;
 	export let stream_every = 1;
 	export let server: {
 		offer: (body: any) => Promise<any>;
@@ -73,21 +74,29 @@
 		const target = event.target as HTMLInputElement;
 		const device_id = target.value;
 
-		await get_video_stream(include_audio, video_source, device_id, track_constraints).then(
-			async (local_stream) => {
-				stream = local_stream;
-				selected_device =
-					available_video_devices.find(
-						(device) => device.deviceId === device_id
-					) || null;
-				options_open = false;
-			}
-		);
+		await get_video_stream(
+			include_audio,
+			video_source,
+			device_id,
+			track_constraints,
+		).then(async (local_stream) => {
+			stream = local_stream;
+			selected_device =
+				available_video_devices.find(
+					(device) => device.deviceId === device_id,
+				) || null;
+			options_open = false;
+		});
 	};
 
 	async function access_webcam(): Promise<void> {
 		try {
-			get_video_stream(include_audio, video_source, null, track_constraints)
+			get_video_stream(
+				include_audio,
+				video_source,
+				null,
+				track_constraints,
+			)
 				.then(async (local_stream) => {
 					webcam_accessed = true;
 					available_video_devices = await get_devices();
@@ -102,12 +111,16 @@
 						.map((track) => track.getSettings()?.deviceId)[0];
 
 					selected_device = used_devices
-						? devices.find((device) => device.deviceId === used_devices) ||
-							available_video_devices[0]
+						? devices.find(
+								(device) => device.deviceId === used_devices,
+							) || available_video_devices[0]
 						: available_video_devices[0];
 				});
 
-			if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+			if (
+				!navigator.mediaDevices ||
+				!navigator.mediaDevices.getUserMedia
+			) {
 				dispatch("error", i18n("image.no_webcam_support"));
 			}
 		} catch (err) {
@@ -123,46 +136,56 @@
 	let stream: MediaStream;
 
 	let webcam_accessed = false;
-    let pc: RTCPeerConnection;
+	let pc: RTCPeerConnection;
 	export let webrtc_id;
 
 	async function start_webrtc(): Promise<void> {
-        if (stream_state === 'closed') {
-            pc = new RTCPeerConnection(rtc_configuration);
-            pc.addEventListener("connectionstatechange",
-                async (event) => {
-                   switch(pc.connectionState) {
-                        case "connected":
-                            stream_state = "open";
-                            _time_limit = time_limit;
-							dispatch("tick");
-                            break;
-                        case "disconnected":
-                            stream_state = "closed";
-							_time_limit = null;
-							stop(pc);
-                            await access_webcam();
-                            break;
-                        default:
-                            break;
-                   }
-                }
-            )
-            stream_state = "waiting"
+		if (stream_state === "closed") {
+			pc = new RTCPeerConnection(rtc_configuration);
+			pc.addEventListener("connectionstatechange", async (event) => {
+				switch (pc.connectionState) {
+					case "connected":
+						stream_state = "open";
+						_time_limit = time_limit;
+						dispatch("tick");
+						break;
+					case "disconnected":
+						stream_state = "closed";
+						_time_limit = null;
+						stop(pc);
+						await access_webcam();
+						break;
+					default:
+						break;
+				}
+			});
+			stream_state = "waiting";
 			webrtc_id = Math.random().toString(36).substring(2);
-            start(stream, pc, mode === "send" ? null: video_source, server.offer, webrtc_id, "video", on_change_cb, rtp_params).then((connection) => {
-				pc = connection;
-			}).catch(() => {
-                console.info("catching")
-                stream_state = "closed";
-                dispatch("error", "Too many concurrent users. Come back later!");
-            });
-        } else {
-            stop(pc);
-            stream_state = "closed";
+			start(
+				stream,
+				pc,
+				mode === "send" ? null : video_source,
+				server.offer,
+				webrtc_id,
+				"video",
+				on_change_cb,
+				rtp_params,
+				undefined,
+				reject_cb,
+			)
+				.then((connection) => {
+					pc = connection;
+				})
+				.catch(() => {
+					console.info("catching");
+					stream_state = "closed";
+				});
+		} else {
+			stop(pc);
+			stream_state = "closed";
 			_time_limit = null;
-            await access_webcam();
-        }
+			await access_webcam();
+		}
 	}
 
 	let options_open = false;
@@ -183,7 +206,7 @@
 		return {
 			destroy() {
 				document.removeEventListener("click", handle_click, true);
-			}
+			},
 		};
 	}
 
@@ -201,11 +224,11 @@
 	{#if stream_state === "open" && include_audio}
 		<div class="audio-indicator">
 			<PulsingIcon
-				stream_state={stream_state}
-				audio_source_callback={audio_source_callback}
+				{stream_state}
+				{audio_source_callback}
 				icon={icon || Mic}
-				icon_button_color={icon_button_color}
-				pulse_color={pulse_color}
+				{icon_button_color}
+				{pulse_color}
 			/>
 		</div>
 	{/if}
@@ -214,8 +237,9 @@
 	<video
 		bind:this={video_source}
 		class:hide={!webcam_accessed}
-        class:flip={(stream_state != "open") || (stream_state === "open" && include_audio)}
-        autoplay={true}
+		class:flip={stream_state != "open" ||
+			(stream_state === "open" && include_audio)}
+		autoplay={true}
 		playsinline={true}
 	/>
 	<!-- svelte-ignore a11y-missing-attribute -->
@@ -229,32 +253,29 @@
 		</div>
 	{:else}
 		<div class="button-wrap">
-			<button
-				on:click={start_webrtc}
-				aria-label={"start stream"}
-			>
-                {#if stream_state === "waiting"}
-                    <div class="icon-with-text">
-                        <div class="icon color-primary" title="spinner">
-                            <Spinner />
-                        </div>
-                        {button_labels.waiting || i18n("audio.waiting")}
-                    </div>
-                {:else if stream_state === "open"}
-                    <div class="icon-with-text">
-                        <div class="icon color-primary" title="stop recording">
-                            <Square />
-                        </div>
-                        {button_labels.stop || i18n("audio.stop")}
-                    </div>
-                {:else}
-                    <div class="icon-with-text">
-                        <div class="icon color-primary" title="start recording">
-                            <Circle />
-                        </div>
-                        {button_labels.start || i18n("audio.record")}
-                    </div>
-                {/if}
+			<button on:click={start_webrtc} aria-label={"start stream"}>
+				{#if stream_state === "waiting"}
+					<div class="icon-with-text">
+						<div class="icon color-primary" title="spinner">
+							<Spinner />
+						</div>
+						{button_labels.waiting || i18n("audio.waiting")}
+					</div>
+				{:else if stream_state === "open"}
+					<div class="icon-with-text">
+						<div class="icon color-primary" title="stop recording">
+							<Square />
+						</div>
+						{button_labels.stop || i18n("audio.stop")}
+					</div>
+				{:else}
+					<div class="icon-with-text">
+						<div class="icon color-primary" title="start recording">
+							<Circle />
+						</div>
+						{button_labels.start || i18n("audio.record")}
+					</div>
+				{/if}
 			</button>
 			{#if !recording}
 				<button
@@ -285,7 +306,8 @@
 					{#each available_video_devices as device}
 						<option
 							value={device.deviceId}
-							selected={selected_device.deviceId === device.deviceId}
+							selected={selected_device.deviceId ===
+								device.deviceId}
 						>
 							{device.label}
 						</option>
@@ -334,19 +356,19 @@
 		align-items: center;
 		margin: 0 var(--spacing-xl);
 		display: flex;
-        justify-content: space-evenly;    
-        /* Add gap between icon and text */
-        gap: var(--size-2);
+		justify-content: space-evenly;
+		/* Add gap between icon and text */
+		gap: var(--size-2);
 	}
 
-    .audio-indicator {
-        position: absolute;
-        top: var(--size-2);
-        right: var(--size-2);
+	.audio-indicator {
+		position: absolute;
+		top: var(--size-2);
+		right: var(--size-2);
 		z-index: var(--layer-2);
 		height: var(--size-5);
 		width: var(--size-5);
-    }
+	}
 
 	@media (--screen-md) {
 		button {

--- a/frontend/shared/webrtc_utils.ts
+++ b/frontend/shared/webrtc_utils.ts
@@ -54,6 +54,7 @@ export async function start(
   on_change_cb: (msg: "change" | "tick") => void = () => { },
   rtp_params = {},
   additional_message_cb: (msg: object) => void = () => { },
+  reject_cb: (msg: object) => void = () => { },
 ) {
   pc = createPeerConnection(pc, node);
   const data_channel = pc.createDataChannel("text");
@@ -100,15 +101,16 @@ export async function start(
     pc.addTransceiver(modality, { direction: "recvonly" });
   }
 
-  await negotiate(pc, server_fn, webrtc_id);
+  await negotiate(pc, server_fn, webrtc_id, reject_cb);
   return pc;
 }
 
-function make_offer(server_fn: any, body): Promise<object> {
+function make_offer(server_fn: any, body, reject_cb: (msg: object) => void = () => { }): Promise<object> {
   return new Promise((resolve, reject) => {
     server_fn(body).then((data) => {
       console.debug("data", data);
       if (data?.status === "failed") {
+        reject_cb(data);
         console.debug("rejecting");
         reject("error");
       }
@@ -121,6 +123,7 @@ async function negotiate(
   pc: RTCPeerConnection,
   server_fn: any,
   webrtc_id: string,
+  reject_cb: (msg: object) => void = () => { },
 ): Promise<void> {
   return pc
     .createOffer()
@@ -151,7 +154,7 @@ async function negotiate(
         sdp: offer.sdp,
         type: offer.type,
         webrtc_id: webrtc_id,
-      });
+      }, reject_cb);
     })
     .then((response) => {
       return response;

--- a/justfile
+++ b/justfile
@@ -11,7 +11,11 @@ upload-all:
 
 # Run a demo with uvicorn
 run name:
-    uvicorn demo.{{name}}.app:stream --port 8000
+    uvicorn demo.{{name}}.app:app --port 8000
+
+# Run the gradio ui for a demo
+gradio name:
+    python demo/{{name}}/app.py
 
 # Run a demo with phone mode
 phone name:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastrtc"
-version = "0.0.2post9"
+version = "0.0.2post10"
 description = "The realtime communication library for Python"
 readme = "README.md"
 license = "apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastrtc"
-version = "0.0.2post8"
+version = "0.0.2post9"
 description = "The realtime communication library for Python"
 readme = "README.md"
 license = "apache-2.0"


### PR DESCRIPTION
The Stream no longer subclasses FastAPI, instead the library is organized around three methods:

* `stream.ui.launch()` - test with gradio, deploy as gradio if you want
* `stream.fastphone()` - get a phone to call into your stream
* `stream.mount` - add to a FastAPI app (potentially other apps in the future)

Also removing the built-in docs routes and instead going to link to a page on the docs. Should allow for faster iteration.
