### PR TITLE
fix track_constraints support

### DIFF
--- a/frontend/shared/stream_utils.ts
+++ b/frontend/shared/stream_utils.ts
@@ -8,7 +8,7 @@ export function handle_error(error: string): void {
 
 export function set_local_stream(
   local_stream: MediaStream | null,
-  video_source: HTMLVideoElement,
+  video_source: HTMLVideoElement
 ): void {
   video_source.srcObject = local_stream;
   video_source.muted = true;
@@ -16,23 +16,31 @@ export function set_local_stream(
 }
 
 export async function get_video_stream(
-  include_audio: boolean,
+  include_audio: boolean | { deviceId: { exact: string } },
   video_source: HTMLVideoElement,
   device_id?: string,
-  track_constraints?: MediaTrackConstraints,
+  track_constraints?:
+    | MediaTrackConstraints
+    | { video: MediaTrackConstraints; audio: MediaTrackConstraints }
 ): Promise<MediaStream> {
-  const fallback_constraints = track_constraints || {
-    width: { ideal: 500 },
-    height: { ideal: 500 },
-  };
+  const video_fallback_constraints = (track_constraints as any)?.video ||
+    track_constraints || {
+      width: { ideal: 500 },
+      height: { ideal: 500 },
+    };
+  const audio_fallback_constraints = (track_constraints as any)?.audio ||
+    track_constraints;
 
   const constraints = {
     video: device_id
-      ? { deviceId: { exact: device_id }, ...fallback_constraints }
-      : fallback_constraints,
-    audio: include_audio,
+      ? { deviceId: { exact: device_id }, ...video_fallback_constraints }
+      : video_fallback_constraints,
+    audio: include_audio
+      ? typeof include_audio === "object"
+        ? { ...include_audio, ...audio_fallback_constraints }
+        : audio_fallback_constraints
+      : false,
   };
-
   return navigator.mediaDevices
     .getUserMedia(constraints)
     .then((local_stream: MediaStream) => {
@@ -43,10 +51,10 @@ export async function get_video_stream(
 
 export function set_available_devices(
   devices: MediaDeviceInfo[],
-  kind: "videoinput" | "audioinput" = "videoinput",
+  kind: "videoinput" | "audioinput" = "videoinput"
 ): MediaDeviceInfo[] {
   const cameras = devices.filter(
-    (device: MediaDeviceInfo) => device.kind === kind,
+    (device: MediaDeviceInfo) => device.kind === kind
   );
 
   return cameras;


### PR DESCRIPTION
#### PR Description
Fixed an issue where track_constraints were not applied in audio-video mode.

#### Issue
When using track_constraints (either custom or default), the constraints were incorrect. For example:
```
  webrtc = WebRTC(
            label="Video Chat",
            modality="audio-video",
            mode="send-receive",
            elem_id="video-source",
            track_constraints={
                "video": {
                    "facingMode": "user",
                    "width": {"ideal": 500},
                    "height": {"ideal": 1300},
                    "frameRate": {"ideal": 30},
                },
                "audio": {
                    "echoCancellation": True,
                    "noiseSuppression": {"exact": False},
                    "autoGainControl": {"exact": True},
                    "sampleRate": {"ideal": 24000},
                    "sampleSize": {"ideal": 16},
                    "channelCount": {"exact": 1},
                },
            }
        )
```
The constraints were not passed through correctly, as shown here:
![image](https://github.com/user-attachments/assets/5b18e90c-1455-4f91-830b-52ba0dc47df7)

#### Solution
Resolved the issue by properly deconstructing the track_constraints input. This ensures that both video and audio constraints are now correctly applied.
